### PR TITLE
feat: validate upload file size

### DIFF
--- a/config/plugins.ts
+++ b/config/plugins.ts
@@ -26,6 +26,7 @@ export default ({ env }) => {
             return `${parentDirId}/${dirId}/${fileName}${extension}`;
           },
         },
+        sizeLimit: env.int('MAX_UPLOAD_SIZE_MB', 10) * 1024 * 1024,
       },
     },
     i18n: {


### PR DESCRIPTION
## 概要
以下のエラーの対応として、ファイルアップロードサイズの上限値を設定した

```
Memory limit of 1024 MiB exceeded with 1143 MiB used. Consider increasing the memory limit, see https://cloud.google.com/run/docs/configuring/memory-limits
```

## インフラ側での対応
環境変数`MAX_UPLOAD_SIZE_MB`にて上限値を決めているため、各環境の開発変数に追加する
※環境変数を追加しなかった場合、デフォルト値が参照される

### 開発者の環境
.envに追記する

```
MAX_UPLOAD_SIZE_MB=10
```

### dev環境
[スクリプト](https://github.com/Hopin-inc/civicship-infrastructure/blob/develop/sh/gcloud/cloud-run/add-env-vars.sh)でデプロイする場合

```
# add-env-vars.sh
gcloud run services update $SERVICE_NAME \
    --region=$REGION \
    --update-env-vars $ENV_VAR_KEY_ENV=$ENV_VAR_VALUE_ENV,$ENV_VAR_KEY_HOST=$ENV_VAR_VALUE_HOST,$ENV_VAR_KEY_ALLOWED_ORIGINS=$ENV_VAR_VALUE_ALLOWED_ORIGINS,$ENV_VAR_KEY_MAX_UPLOAD_SIZE_MB=$ENV_VAR_VALUE_MAX_UPLOAD_SIZE_MB
```

```
# .env.kyoso-dev
ENV_VAR_KEY_MAX_UPLOAD_SIZE_MB=MAX_UPLOAD_SIZE_MB
ENV_VAR_VALUE_MAX_UPLOAD_SIZE_MB=10
```

コンソールでデプロイする場合
<img width="860" alt="スクリーンショット 2025-05-16 0 03 43" src="https://github.com/user-attachments/assets/ae2fbfca-8f4e-40d1-9d98-4583dcdf19c9" />
<img width="852" alt="スクリーンショット 2025-05-18 1 20 18" src="https://github.com/user-attachments/assets/474129fe-5ef8-4eab-ac5d-438779b45054" />

### prod環境
dev環境と同じ